### PR TITLE
Bug fix for animation frame loading

### DIFF
--- a/TiledSharp/src/Tileset.cs
+++ b/TiledSharp/src/Tileset.cs
@@ -84,7 +84,7 @@ namespace TiledSharp
                 Tiles = new List<TmxTilesetTile>();
                 foreach (var xTile in xTileset.Elements("tile"))
                 {
-                    var tile = new TmxTilesetTile(xTile, Terrains, FirstGid, tmxDir);
+                    var tile = new TmxTilesetTile(xTile, Terrains, tmxDir);
                     Tiles.Add(tile);
                 }
 
@@ -128,7 +128,6 @@ namespace TiledSharp
     public class TmxTilesetTile
     {
         public int Id {get; private set;}
-		public int Gid {get; private set;}
         public List<TmxTerrain> TerrainEdges {get; private set;}
         public double Probability {get; private set;}
 
@@ -153,11 +152,10 @@ namespace TiledSharp
             get { return TerrainEdges[3]; }
         }
 
-        public TmxTilesetTile(XElement xTile, TmxList<TmxTerrain> Terrains, int firstGid,
+        public TmxTilesetTile(XElement xTile, TmxList<TmxTerrain> Terrains,
                        string tmxDir = "")
         {
             Id = (int)xTile.Attribute("id");
-            Gid = Id + firstGid;
 
             TerrainEdges = new List<TmxTerrain>(4);
 


### PR DESCRIPTION
Previously, the code was passing each <animation> tag (of which there
is, at most, one) to the TmxAnimationFrame constructor.  Now, it will
pass the <frame> tags to that constructor.  This fixes a bug where a
null reference exception was thrown whenever loading a .TMX file which
uses animations.
