### PR TITLE
NullReferenceException fix in TiledDocument.ReadXml

### DIFF
--- a/TiledSharp/src/TiledCore.cs
+++ b/TiledSharp/src/TiledCore.cs
@@ -22,25 +22,29 @@ namespace TiledSharp
             XDocument xDoc;
 
             var asm = Assembly.GetEntryAssembly();
-            var manifest = asm.GetManifestResourceNames();
 
-            var fileResPath = filepath.Replace(
+            if (asm != null)
+            {
+                var manifest = asm.GetManifestResourceNames();
+
+                var fileResPath = filepath.Replace(
                     Path.DirectorySeparatorChar.ToString(), ".");
-            var fileRes = Array.Find(manifest, s => s.EndsWith(fileResPath));
+                var fileRes = Array.Find(manifest, s => s.EndsWith(fileResPath));
 
-            // If there is a resource in the assembly, load the resource
-            // Otherwise, assume filepath is an explicit path
-            if (fileRes != null)
-            {
-                Stream xmlStream = asm.GetManifestResourceStream(fileRes);
-                xDoc = XDocument.Load(xmlStream);
-                TmxDirectory = "";
+                // If there is a resource in the assembly, load the resource
+                // Otherwise, assume filepath is an explicit path
+                if (fileRes != null)
+                {
+                    Stream xmlStream = asm.GetManifestResourceStream(fileRes);
+                    xDoc = XDocument.Load(xmlStream);
+                    TmxDirectory = "";
+
+                    return xDoc;
+                }
             }
-            else
-            {
-                xDoc = XDocument.Load(filepath);
-                TmxDirectory = Path.GetDirectoryName(filepath);
-            }
+
+            xDoc = XDocument.Load(filepath);
+            TmxDirectory = Path.GetDirectoryName(filepath);
 
             return xDoc;
         }


### PR DESCRIPTION
Fixes NullReferenceException when a map is loaded via a process with a native entry point; `Assembly.GetEntryAssembly()` can return null, and then the rest of it explodes. You can check this out by running TiledSharp via the XNA Content Pipeline or another application that doesn't have a standard `public static void Main` entry point, such as MSTest (I think).
