### PR TITLE
Fix ArgumentNullException when loading maps edited using Tile Collision Editor

### DIFF
--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -21,7 +21,7 @@ namespace TiledSharp
 
         public TmxObjectGroup(XElement xObjectGroup)
         {
-            Name = (string)xObjectGroup.Attribute("name");
+            Name = (string)xObjectGroup.Attribute("name") ?? "";
             Color = new TmxColor(xObjectGroup.Attribute("color"));
             Opacity = (double?)xObjectGroup.Attribute("opacity") ?? 1.0;
             Visible = (bool?)xObjectGroup.Attribute("visible") ?? true;
@@ -68,7 +68,7 @@ namespace TiledSharp
                 Y = (double)xObject.Attribute("y");
                 Width = (double?)xObject.Attribute("width") ?? 0.0;
                 Height = (double?)xObject.Attribute("height") ?? 0.0;
-                Type = (string)xObject.Attribute("type");
+                Type = (string)xObject.Attribute("type") ?? "";
                 Visible = (bool?)xObject.Attribute("visible") ?? true;
                 Rotation = (double?)xObject.Attribute("rotation") ?? 0.0;
 


### PR DESCRIPTION
Tiledsharp throwed an error when loading maps which were edited by the
"Tile collision editor" feature of Tiled.

This feature created this inside the tileset
```xml
<tile id="27">
   <objectgroup draworder="index">
    <object id="0" x="3" y="4" width="12" height="7"/>
   </objectgroup>
  </tile>
````

The objectgroup does not have a name, and the object does not have a type

