### PR TITLE
TmxImageLayer now handles width and height attributes not being present.

### DIFF
--- a/TiledSharp/src/ImageLayer.cs
+++ b/TiledSharp/src/ImageLayer.cs
@@ -9,8 +9,8 @@ namespace TiledSharp
     public class TmxImageLayer : ITmxElement
     {
         public string Name {get; private set;}
-        public int Width {get; private set;}
-        public int Height {get; private set;}
+        public int? Width {get; private set;}
+        public int? Height {get; private set;}
 
         public bool Visible {get; private set;}
         public double Opacity {get; private set;}
@@ -22,8 +22,9 @@ namespace TiledSharp
         public TmxImageLayer(XElement xImageLayer, string tmxDir = "")
         {
             Name = (string) xImageLayer.Attribute("name");
-            Width = (int) xImageLayer.Attribute("width");
-            Height = (int) xImageLayer.Attribute("height");
+
+            Width = (int?) xImageLayer.Attribute("width");
+            Height = (int?) xImageLayer.Attribute("height");
             Visible = (bool?) xImageLayer.Attribute("visible") ?? true;
             Opacity = (double?) xImageLayer.Attribute("opacity") ?? 1.0;
 


### PR DESCRIPTION
A map I'm working on has an image layer without height or width attributes. The map was created using the latest version of Tiled (0.15). The map would fail to load through TiledSharp without those attributes.

This change makes height and width nullable, to handle image layers without them.

