### PR TITLE
Added support for xml "offsetx" and "offsety" attributes & Fixed ParsePoints to properly parse decimals.

### DIFF
--- a/TiledSharp/src/ImageLayer.cs
+++ b/TiledSharp/src/ImageLayer.cs
@@ -10,7 +10,9 @@ namespace TiledSharp
     {
         public string Name {get; private set;}
         public int? Width {get; private set;}
-        public int? Height {get; private set;}
+        public int? Height {get; private set; }
+        public float? XOffset {get; private set;}
+        public float? YOffset {get; private set;}
 
         public bool Visible {get; private set;}
         public double Opacity {get; private set;}
@@ -27,6 +29,8 @@ namespace TiledSharp
             Height = (int?) xImageLayer.Attribute("height");
             Visible = (bool?) xImageLayer.Attribute("visible") ?? true;
             Opacity = (double?) xImageLayer.Attribute("opacity") ?? 1.0;
+            XOffset = (float?) xImageLayer.Attribute("offsetx");
+            YOffset = (float?) xImageLayer.Attribute("offsety");
 
             Image = new TmxImage(xImageLayer.Element("image"), tmxDir);
 

--- a/TiledSharp/src/Layer.cs
+++ b/TiledSharp/src/Layer.cs
@@ -13,7 +13,9 @@ namespace TiledSharp
     {
         public string Name {get; private set;}
         public double Opacity {get; private set;}
-        public bool Visible {get; private set;}
+        public bool Visible {get; private set; }
+        public float? XOffset {get; private set;}
+        public float? YOffset {get; private set;}
 
         public Collection<TmxLayerTile> Tiles {get; private set;}
         public PropertyDict Properties {get; private set;}
@@ -23,6 +25,8 @@ namespace TiledSharp
             Name = (string)xLayer.Attribute("name");
             Opacity = (double?)xLayer.Attribute("opacity") ?? 1.0;
             Visible = (bool?)xLayer.Attribute("visible") ?? true;
+            XOffset = (float?)xLayer.Attribute("offsetx");
+            YOffset = (float?)xLayer.Attribute("offsety");
 
             var xData = xLayer.Element("data");
             var encoding = (string)xData.Attribute("encoding");

--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -15,7 +15,9 @@ namespace TiledSharp
         public TmxColor Color {get; private set;}
         public DrawOrderType DrawOrder {get; private set;}
         public double Opacity {get; private set;}
-        public bool Visible {get; private set;}
+        public bool Visible {get; private set; }
+        public float? XOffset {get; private set;}
+        public float? YOffset {get; private set;}
 
         public TmxList<TmxObject> Objects {get; private set;}
         public PropertyDict Properties {get; private set;}
@@ -26,6 +28,8 @@ namespace TiledSharp
             Color = new TmxColor(xObjectGroup.Attribute("color"));
             Opacity = (double?)xObjectGroup.Attribute("opacity") ?? 1.0;
             Visible = (bool?)xObjectGroup.Attribute("visible") ?? true;
+            XOffset = (float?)xObjectGroup.Attribute("offsetx");
+            YOffset = (float?)xObjectGroup.Attribute("offsety");
 
             var drawOrderDict = new Dictionary<string, DrawOrderType> {
                 {"unknown", DrawOrderType.UnknownOrder},

--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -139,8 +139,8 @@ namespace TiledSharp
         public TmxObjectPoint(string s)
         {
             var pt = s.Split(',');
-            X = double.Parse(pt[0]);
-            Y = double.Parse(pt[1]);
+            X = double.Parse(pt[0], NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+            Y = double.Parse(pt[1], NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
         }
     }
 


### PR DESCRIPTION
Layer, ImageLayer and ObjectGroup now compatible with Tiled x and y
offsets.

Fixed ParsePoints to properly parse decimals