### PR TITLE
Load maps from streams and xdocuments.

### DIFF
--- a/TiledSharp/src/Map.cs
+++ b/TiledSharp/src/Map.cs
@@ -35,9 +35,14 @@ namespace TiledSharp
             Load(ReadXml(filename));
         }
 
-        public TmxMap(Stream fileStream)
+        public TmxMap(Stream inputStream)
         {
-            Load(XDocument.Load(fileStream));
+            Load(XDocument.Load(inputStream));
+        }
+
+        public TmxMap(XDocument xDoc)
+        {
+            Load(xDoc);
         }
          
         private void Load(XDocument xDoc)

--- a/TiledSharp/src/Map.cs
+++ b/TiledSharp/src/Map.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 using System.Globalization;
+using System.IO;
 
 namespace TiledSharp
 {
@@ -31,9 +32,17 @@ namespace TiledSharp
 
         public TmxMap(string filename)
         {
-            XDocument xDoc = ReadXml(filename);
-            var xMap = xDoc.Element("map");
+            Load(ReadXml(filename));
+        }
 
+        public TmxMap(Stream fileStream)
+        {
+            Load(XDocument.Load(fileStream));
+        }
+         
+        private void Load(XDocument xDoc)
+        {
+            var xMap = xDoc.Element("map");
             Version = (string) xMap.Attribute("version");
 
             Width = (int) xMap.Attribute("width");

--- a/TiledSharp/src/TiledCore.cs
+++ b/TiledSharp/src/TiledCore.cs
@@ -18,6 +18,11 @@ namespace TiledSharp
     {
         public string TmxDirectory {get; private set;}
 
+        public TmxDocument()
+        {
+            TmxDirectory = string.Empty;
+        }
+
         protected XDocument ReadXml(string filepath)
         {
             XDocument xDoc;


### PR DESCRIPTION
Addresses issue #32 by exposing constructors for creating a map from a stream or an XDocument loaded directly.

The seemingly unrelated change to TiledCore is due to ReadXml not always being called now, so we need a non-null TmxDirectory.