### PR TITLE
Added reading of object unique IDs

### DIFF
--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -57,6 +57,7 @@ namespace TiledSharp
     {
         // Many TmxObjectTypes are distinguished by null values in fields
         // It might be smart to subclass TmxObject
+        public int Id {get; private set;}
         public string Name {get; private set;}
         public TmxObjectType ObjectType {get; private set;}
         public string Type {get; private set;}
@@ -73,6 +74,7 @@ namespace TiledSharp
 
         public TmxObject(XElement xObject)
         {
+            Id = (int?)xObject.Attribute("id") ?? 0;
             Name = (string)xObject.Attribute("name") ?? String.Empty;
             X = (double)xObject.Attribute("x");
             Y = (double)xObject.Attribute("y");


### PR DESCRIPTION
These were added in Tiled 0.11.

When present, the ID is guaranteed to be unique on a given map. For older maps it should be fine to default it to 0.