### PR TITLE
Added support for elements introduced in Tiled 1.0

### DIFF
--- a/TiledSharp/TiledSharp.csproj
+++ b/TiledSharp/TiledSharp.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="src\Group.cs" />
     <Compile Include="src\TiledCore.cs" />
     <Compile Include="src\Map.cs" />
     <Compile Include="src\Layer.cs" />

--- a/TiledSharp/src/Group.cs
+++ b/TiledSharp/src/Group.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Distributed as part of TiledSharp, Copyright 2012 Marshall Ward
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+using System;
 using System.Xml.Linq;
 
 namespace TiledSharp

--- a/TiledSharp/src/Group.cs
+++ b/TiledSharp/src/Group.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace TiledSharp
+{
+    public class TmxGroup : ITmxElement
+    {
+        public string Name { get; private set; }
+
+        public double Opacity { get; private set; }
+        public bool Visible { get; private set; }
+        public double? OffsetX { get; private set; }
+        public double? OffsetY { get; private set; }
+
+        public TmxList<TmxLayer> Layers { get; private set; }
+        public TmxList<TmxObjectGroup> ObjectGroups { get; private set; }
+        public TmxList<TmxImageLayer> ImageLayers { get; private set; }
+        public TmxList<TmxGroup> Groups { get; private set; }
+        public PropertyDict Properties { get; private set; }
+
+        public TmxGroup(XElement xGroup, int width, int height, string tmxDirectory)
+        {
+            Name = (string)xGroup.Attribute("name") ?? String.Empty;
+            Opacity = (double?)xGroup.Attribute("opacity") ?? 1.0;
+            Visible = (bool?)xGroup.Attribute("visible") ?? true;
+            OffsetX = (double?)xGroup.Attribute("offsetx") ?? 0.0;
+            OffsetY = (double?)xGroup.Attribute("offsety") ?? 0.0;
+
+            Properties = new PropertyDict(xGroup.Element("properties"));
+
+            Layers = new TmxList<TmxLayer>();
+            foreach (var e in xGroup.Elements("layer"))
+                Layers.Add(new TmxLayer(e, width, height));
+
+            ObjectGroups = new TmxList<TmxObjectGroup>();
+            foreach (var e in xGroup.Elements("objectgroup"))
+                ObjectGroups.Add(new TmxObjectGroup(e));
+
+            ImageLayers = new TmxList<TmxImageLayer>();
+            foreach (var e in xGroup.Elements("imagelayer"))
+                ImageLayers.Add(new TmxImageLayer(e, tmxDirectory));
+
+            Groups = new TmxList<TmxGroup>();
+            foreach (var e in xGroup.Elements("group"))
+                Groups.Add(new TmxGroup(e, width, height, tmxDirectory));
+        }
+    }
+}

--- a/TiledSharp/src/Map.cs
+++ b/TiledSharp/src/Map.cs
@@ -12,6 +12,7 @@ namespace TiledSharp
     public class TmxMap : TmxDocument
     {
         public string Version {get; private set;}
+        public string TiledVersion { get; private set; }
         public int Width {get; private set;}
         public int Height {get; private set;}
         public int TileWidth {get; private set;}
@@ -49,6 +50,7 @@ namespace TiledSharp
         {
             var xMap = xDoc.Element("map");
             Version = (string) xMap.Attribute("version");
+            TiledVersion = (string)xMap.Attribute("tiledversion");
 
             Width = (int) xMap.Attribute("width");
             Height = (int) xMap.Attribute("height");

--- a/TiledSharp/src/Map.cs
+++ b/TiledSharp/src/Map.cs
@@ -29,6 +29,7 @@ namespace TiledSharp
         public TmxList<TmxLayer> Layers {get; private set;}
         public TmxList<TmxObjectGroup> ObjectGroups {get; private set;}
         public TmxList<TmxImageLayer> ImageLayers {get; private set;}
+        public TmxList<TmxGroup> Groups { get; private set; }
         public PropertyDict Properties {get; private set;}
 
         public TmxMap(string filename)
@@ -123,6 +124,10 @@ namespace TiledSharp
             ImageLayers = new TmxList<TmxImageLayer>();
             foreach (var e in xMap.Elements("imagelayer"))
                 ImageLayers.Add(new TmxImageLayer(e, TmxDirectory));
+
+            Groups = new TmxList<TmxGroup>();
+            foreach (var e in xMap.Elements("group"))
+                Groups.Add(new TmxGroup(e, Width, Height, TmxDirectory));
         }
     }
 

--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -68,6 +68,7 @@ namespace TiledSharp
         public double Rotation {get; private set;}
         public TmxLayerTile Tile {get; private set;}
         public bool Visible {get; private set;}
+        public TmxText Text { get; private set; }
 
         public Collection<TmxObjectPoint> Points {get; private set;}
         public PropertyDict Properties {get; private set;}
@@ -113,6 +114,12 @@ namespace TiledSharp
             }
             else ObjectType = TmxObjectType.Basic;
 
+            var xText = xObject.Element("text");
+            if (xText != null)
+            {
+                Text = new TmxText(xText);
+            }
+
             Properties = new PropertyDict(xObject.Element("properties"));
         }
 
@@ -152,6 +159,62 @@ namespace TiledSharp
         }
     }
 
+    public class TmxText
+    {
+        public string FontFamily { get; private set; }
+        public int PixelSize { get; private set; }
+        public bool Wrap { get; private set; }
+        public TmxColor Color { get; private set; }
+        public bool Bold { get; private set; }
+        public bool Italic { get; private set; }
+        public bool Underline { get; private set; }
+        public bool Strikeout { get; private set; }
+        public bool Kerning { get; private set; }
+        public TmxAlignment Alignment { get; private set; }
+        public string Value { get; private set; }
+
+        public TmxText(XElement xText)
+        {
+            FontFamily = (string)xText.Attribute("fontfamily") ?? "sand-serif";
+            PixelSize = (int?)xText.Attribute("pixelsize") ?? 16;
+            Wrap = (bool?)xText.Attribute("wrap") ?? false;
+            Color = new TmxColor(xText.Attribute("color"));
+            Bold = (bool?)xText.Attribute("bold") ?? false;
+            Italic = (bool?)xText.Attribute("italic") ?? false;
+            Underline = (bool?)xText.Attribute("underline") ?? false;
+            Strikeout = (bool?)xText.Attribute("strikeout") ?? false;
+            Kerning = (bool?)xText.Attribute("kerning") ?? true;
+            Alignment = new TmxAlignment(xText.Attribute("halign"), xText.Attribute("valign"));
+            Value = xText.Value;
+        }
+    }
+
+    public class TmxAlignment
+    {
+        public TmxHorizontalAlignment Horizontal { get; private set; }
+        public TmxVerticalAlignment Vertical { get; private set; }
+
+        public TmxAlignment(XAttribute halign, XAttribute valign)
+        {
+            var xHorizontal = (string)halign ?? "Left";
+            Horizontal = (TmxHorizontalAlignment)Enum.Parse(typeof(TmxHorizontalAlignment),
+                FirstLetterToUpperCase(xHorizontal));
+
+            var xVertical = (string)valign ?? "Top";
+            Vertical = (TmxVerticalAlignment)Enum.Parse(typeof(TmxVerticalAlignment),
+                FirstLetterToUpperCase(xVertical));
+        }
+
+        private string FirstLetterToUpperCase(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+            return str[0].ToString().ToUpper() + str.Substring(1);
+        }
+    }
+
     public enum TmxObjectType
     {
         Basic,
@@ -166,5 +229,20 @@ namespace TiledSharp
         UnknownOrder = -1,
         TopDown,
         IndexOrder
+    }
+
+    public enum TmxHorizontalAlignment
+    {
+        Left,
+        Center,
+        Right,
+        Justify
+    }
+
+    public enum TmxVerticalAlignment
+    {
+        Top,
+        Center,
+        Bottom
     }
 }

--- a/TiledSharp/src/Tileset.cs
+++ b/TiledSharp/src/Tileset.cs
@@ -134,6 +134,7 @@ namespace TiledSharp
         public int Id {get; private set;}
         public Collection<TmxTerrain> TerrainEdges {get; private set;}
         public double Probability {get; private set;}
+        public string Type { get; private set; }
 
         public PropertyDict Properties {get; private set;}
         public TmxImage Image {get; private set;}
@@ -179,6 +180,7 @@ namespace TiledSharp
             }
 
             Probability = (double?)xTile.Attribute("probability") ?? 1.0;
+            Type = (string)xTile.Attribute("type");
             Image = new TmxImage(xTile.Element("image"), tmxDir);
 
             ObjectGroups = new TmxList<TmxObjectGroup>();


### PR DESCRIPTION
Added support for new group element which is a group layer that can have other layers as child elements. This means layers now form a hierarchy.
Added Text objects, identified by a new text element which is used as a child of the object element.
Added a tile.type attribute for supporting typed tiles.
Added support for tiledversion.