### PR TITLE
fix 'value cannot be null' exception when tiles don't have GIDs

### DIFF
--- a/TiledSharp/src/Layer.cs
+++ b/TiledSharp/src/Layer.cs
@@ -63,10 +63,22 @@ namespace TiledSharp
                 int k = 0;
                 foreach (var e in xData.Elements("tile"))
                 {
-                    var gid = (uint)e.Attribute("gid");
+                    var gid = (uint?)e.Attribute("gid");
+                    uint _gid;
+
+                    if (gid.HasValue)
+                    {
+                        _gid = (uint)gid.Value;
+                    }
+                    else
+                    {
+                        _gid = 0;
+                    }
+
                     var x = k % width;
                     var y = k / width;
-                    Tiles.Add(new TmxLayerTile(gid, x, y));
+                    
+                    Tiles.Add(new TmxLayerTile(_gid, x, y));
                     k++;
                 }
             }

--- a/TiledSharp/src/Layer.cs
+++ b/TiledSharp/src/Layer.cs
@@ -63,22 +63,12 @@ namespace TiledSharp
                 int k = 0;
                 foreach (var e in xData.Elements("tile"))
                 {
-                    var gid = (uint?)e.Attribute("gid");
-                    uint _gid;
-
-                    if (gid.HasValue)
-                    {
-                        _gid = (uint)gid.Value;
-                    }
-                    else
-                    {
-                        _gid = 0;
-                    }
+                    var gid = (uint?)e.Attribute("gid") ?? 0;
 
                     var x = k % width;
                     var y = k / width;
                     
-                    Tiles.Add(new TmxLayerTile(_gid, x, y));
+                    Tiles.Add(new TmxLayerTile(gid, x, y));
                     k++;
                 }
             }


### PR DESCRIPTION
At least in the Tiled version I'm currently using (1.2.1), tiled will omit the 'gid' attribute for empty tiles. In that case, the entry will just be an empty tile tag (and the tile gid will implicitly be 0, the 'no tile' gid).