### PR TITLE
Fix typo in TmxObject ctor (pass X,Y inst. of X,X)

### DIFF
--- a/TiledSharp/src/ObjectGroup.cs
+++ b/TiledSharp/src/ObjectGroup.cs
@@ -98,7 +98,7 @@ namespace TiledSharp
             {
                 Tile = new TmxLayerTile((uint)xGid,
                     Convert.ToInt32(Math.Round(X)),
-                    Convert.ToInt32(Math.Round(X)));
+                    Convert.ToInt32(Math.Round(Y)));
                 ObjectType = TmxObjectType.Tile;
             }
             else if (xEllipse != null)


### PR DESCRIPTION
See #61 