### PR TITLE
Support custom loading of xml data

### DIFF
--- a/TiledSharp/src/Map.cs
+++ b/TiledSharp/src/Map.cs
@@ -36,18 +36,18 @@ namespace TiledSharp
 
         public TmxList<ITmxLayer> Layers { get; private set; }
 
-        public TmxMap(string filename)
+        public TmxMap(string filename, ICustomLoader customLoader = null) : base(customLoader)
         {
             Load(ReadXml(filename));
         }
 
-        public TmxMap(Stream inputStream)
+        public TmxMap(Stream inputStream, ICustomLoader customLoader = null) : base(customLoader)
         {
             XmlReader xmlReader = XmlReader.Create (inputStream);
             Load(XDocument.Load(xmlReader));
         }
 
-        public TmxMap(XDocument xDoc)
+        public TmxMap(XDocument xDoc, ICustomLoader customLoader = null) : base(customLoader)
         {
             Load(xDoc);
         }
@@ -116,7 +116,7 @@ namespace TiledSharp
 
             Tilesets = new TmxList<TmxTileset>();
             foreach (var e in xMap.Elements("tileset"))
-                Tilesets.Add(new TmxTileset(e, TmxDirectory));
+                Tilesets.Add(new TmxTileset(e, TmxDirectory, CustomLoader));
 
             Layers = new TmxList<ITmxLayer>();
             TileLayers = new TmxList<TmxLayer>();

--- a/TiledSharp/src/TiledCore.cs
+++ b/TiledSharp/src/TiledCore.cs
@@ -14,17 +14,22 @@ using System.Xml.Linq;
 
 namespace TiledSharp
 {
-    public class TmxDocument
+    public abstract class TmxDocument
     {
         public string TmxDirectory {get; private set;}
 
-        public TmxDocument()
+        protected ICustomLoader CustomLoader { get; }
+
+        public TmxDocument(ICustomLoader customLoader)
         {
+            CustomLoader = customLoader;
             TmxDirectory = string.Empty;
         }
 
         protected XDocument ReadXml(string filepath)
         {
+            if (CustomLoader != null)
+                return CustomLoader.ReadXml(filepath);
             XDocument xDoc;
 
             var asm = Assembly.GetEntryAssembly();
@@ -58,6 +63,11 @@ namespace TiledSharp
 
             return xDoc;
         }
+    }
+
+    public interface ICustomLoader
+    {
+        XDocument ReadXml(string filepath);
     }
 
     public interface ITmxElement

--- a/TiledSharp/src/Tileset.cs
+++ b/TiledSharp/src/Tileset.cs
@@ -30,11 +30,11 @@ namespace TiledSharp
         public TmxList<TmxTerrain> Terrains {get; private set;}
 
         // TSX file constructor
-        public TmxTileset(XContainer xDoc, string tmxDir) :
-            this(xDoc.Element("tileset"), tmxDir) { }
+        public TmxTileset(XContainer xDoc, string tmxDir, ICustomLoader customLoader = null) :
+            this(xDoc.Element("tileset"), tmxDir, customLoader) { }
 
         // TMX tileset element constructor
-        public TmxTileset(XElement xTileset, string tmxDir = "")
+        public TmxTileset(XElement xTileset, string tmxDir = "", ICustomLoader customLoader = null) : base(customLoader)
         {
             var xFirstGid = xTileset.Attribute("firstgid");
             var source = (string) xTileset.Attribute("source");
@@ -49,7 +49,7 @@ namespace TiledSharp
 
                 // Everything else is in the TSX file
                 var xDocTileset = ReadXml(source);
-                var ts = new TmxTileset(xDocTileset, TmxDirectory);
+                var ts = new TmxTileset(xDocTileset, TmxDirectory, CustomLoader);
                 Name = ts.Name;
                 TileWidth = ts.TileWidth;
                 TileHeight = ts.TileHeight;


### PR DESCRIPTION
In order to enable loading of tmx and tsx file structures from other sources (be it a web source, a database or similar), I added an optional custom loader constructor parameter which will be used for filename to XDocument conversion.
This custom loader will be inherited down from TmxMap to TmxTileset if source is set.